### PR TITLE
Fix (very) minor typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ let input = {
     labels: ["Apples", "Pears", "Oranges", "Peaches"]
 };
 let width = 800;
-left height = 400;
+let height = 400;
 
 let svg = svgTreemap(input, width, height);
 ```


### PR DESCRIPTION
`left` -> `let`